### PR TITLE
fix: updated references from personal repo to persona org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @derektamsen
+*       @persona-id/infrastructure

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,8 +35,8 @@ archives:
 
 dockers:
   - image_templates:
-      - "ghcr.io/derektamsen/{{.ProjectName}}:{{ .Tag }}"
-      - "ghcr.io/derektamsen/{{.ProjectName}}:latest"
+      - "ghcr.io/persona-id/{{.ProjectName}}:{{ .Tag }}"
+      - "ghcr.io/persona-id/{{.ProjectName}}:latest"
 
 checksum:
   name_template: 'checksums.txt'

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Download the binary:
 
 ```shell
 # download the latest linux release of squid-check and the checksum file
-curl -L -o squid-check_Linux_x86_64.tar.gz https://github.com/derektamsen/squid-check/releases/latest/download/squid-check_Linux_x86_64.tar.gz
-curl -L -o checksums.txt https://github.com/derektamsen/squid-check/releases/latest/download/checksums.txt
+curl -L -o squid-check_Linux_x86_64.tar.gz https://github.com/persona-id/squid-check/releases/latest/download/squid-check_Linux_x86_64.tar.gz
+curl -L -o checksums.txt https://github.com/persona-id/squid-check/releases/latest/download/checksums.txt
 
 
 # check the shasum and extract it if it matches
@@ -96,7 +96,7 @@ Suggested installation:
 We pre-build a container image for squid-check. It can be used in conjunction with a squid kubernetes deployment.
 
 ```shell
-docker pull ghcr.io/derektamsen/squid-check:latest
+docker pull ghcr.io/persona-id/squid-check:latest
 ```
 
 ## Development

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/derektamsen/squid-check
+module github.com/persona-id/squid-check
 
 go 1.21.3


### PR DESCRIPTION
Update references post move from personal repo to persona org repo. This
will also update goreleaser to push container images to org.
