### PR TITLE
feat: add go build version output and version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# ignore built binary
+squid-check

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Usage of /usr/local/bin/squid-check:
         Address of squid proxy (default "127.0.0.1:3128")
   -target-address string
         Address of proxied health check target (default "127.0.0.1:8080")
+  -version
+        Print version and exit
 ```
 
 ## Installation
@@ -107,3 +109,10 @@ To use the environment:
 
 1. `docker-compose up --build`
 2. Make requests to `http://localhost:8080/healthz` or another endpoint served by squid-check. If you have the vscode rest client installed you can use `http_client_tests.rest` to send requests to the various endpoints.
+
+## Releasing
+
+The project is using [goreleaser](https://goreleaser.com) and will automatically publish a release on new tag push. Currently, it builds both a linux binary and a container image.
+
+1. `git tag -a vX.Y.Z`
+2. `git push origin vX.Y.Z`

--- a/main_test.go
+++ b/main_test.go
@@ -60,6 +60,33 @@ func mockProxy(w http.ResponseWriter, r *http.Request) {
 	io.Copy(w, resp.Body)
 }
 
+// TestNewBuildInfo suite to test creating a new buildInfo struct
+func TestNewBuildInfo(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected *buildInfo
+	}{
+		{
+			name: "returnsBuildInfoWithDefaultValues",
+			expected: &buildInfo{
+				goVersion: "unknown",
+				version:   "unknown",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newBuildInfo()
+
+			// compare expected to actual
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("got %v; expect %v", got, tc.expected)
+			}
+		})
+	}
+}
+
 // TestNewProxyClient suite to test creating a new proxy client
 func TestNewProxyClient(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Add `-version` flag and output to startup to output git sha and go version used during build
