### PR TITLE
feat: add release-please CI action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,11 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,17 +2,29 @@ name: Release
 
 on:
   push:
-    tags: [ 'v*' ]
+    branches:
+      - main
 
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
 
   goreleaser:
     runs-on: ubuntu-latest
-
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/README.md
+++ b/README.md
@@ -112,7 +112,22 @@ To use the environment:
 
 ## Releasing
 
-The project is using [goreleaser](https://goreleaser.com) and will automatically publish a release on new tag push. Currently, it builds both a linux binary and a container image.
+This repo uses the [release-please](https://github.com/googleapis/release-please)
+action. Release please leverages [conventional commits](https://www.conventionalcommits.org)
+formatting to automatically collect release notes to create the next semver tag.
+Once the release pr is merged release please will tag the next version and run
+goreleaser which will automatically build the binaries and attach them to the
+github release. The release pr will continue to collect changes since the last
+time a release was tagged.
 
-1. `git tag -a vX.Y.Z`
-2. `git push origin vX.Y.Z`
+1. Create and merge any number of prs to main following conventional commits
+formatting. You can continue to merge changes to main and release please will
+continue to append changes to the open release pr since the last release was
+tagged.
+2. When you are ready to release the changes created in step 1,
+[merge the open release pr](https://github.com/persona-id/squid-check/labels/autorelease%3A%20pending).
+This will trigger CI to create a new tag and github release. CI will also run
+[goreleaser](https://goreleaser.com) which will build the binaries and update
+the github release with the artifacts.
+3. The changes merged in step 1 are now available on the
+[latest github release](https://github.com/persona-id/squid-check/releases/latest)


### PR DESCRIPTION
Add release-please to the release ci action. This will automatically collect
commits merged to main since the last release. Then once the release pr
is merged it will create a tag, create a github release, build the artifacts
using goreleaser, and post the artifacts to the github release.

feat(ci): add dependabot updater config for actions
  Add dependabot updater configuration for actions to keep the actions
  up to date.