### PR TITLE
Fix/startup message log level

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func main() {
 	mux.Handle("/target", targetHandler())
 
 	// start http server
-	slog.Error(fmt.Sprintf(
+	slog.Info(fmt.Sprintf(
 		"version %s built with %s, Listening on %s",
 		buildInfo.version,
 		buildInfo.goVersion,

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var flags cliFlags = cliFlags{}
 
 func init() {
 	flag.StringVar(&flags.listenAddress, "listen-address", "0.0.0.0:8080", "Address to listen on")
-	flag.StringVar(&flags.logLevel, "log-level", "warn", "Log level")
+	flag.StringVar(&flags.logLevel, "log-level", "info", "Log level")
 	flag.StringVar(&flags.proxyAddress, "proxy-address", "127.0.0.1:3128", "Address of squid proxy")
 	flag.StringVar(&flags.targetAddress, "target-address", "127.0.0.1:8080", "Address of proxied health check target")
 	flag.StringVar(&flags.targetPath, "target-path", "/target", "Address of proxied health check target path. i.e /target")


### PR DESCRIPTION
When program starts first log message should not come as "Warning" as it is confusing and message itself is meant to inform. 