### PR TITLE
feat: update to go 1.25.1, cleanup container images, add devcontainer

### DIFF
--- a/.devcontainer/bin/install-dependencies
+++ b/.devcontainer/bin/install-dependencies
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+go install github.com/goreleaser/goreleaser/v2@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"customizations": {
+		"vscode": {
+			// Enable some extensions inside the devcontainer.
+			"extensions": [
+				"golang.go"
+			]
+		}
+	},
+	"dockerComposeFile": [
+		"../docker-compose.yaml",
+		"docker-compose.devcontainer.yaml"
+	],
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.25.1"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8080],
+	"name": "squid-check",
+	// Install extra packages we might need that do not have a feature.
+	"postCreateCommand": "bash -i .devcontainer/bin/install-dependencies",
+	// list of docker compose services to start
+	"runServices": [
+		"squid"
+	],
+	// the docker compose service to use as the dev container
+	"service": "devcontainer",
+	// default path for the devcontainer
+	"workspaceFolder": "/workspace"
+}

--- a/.devcontainer/docker-compose.devcontainer.yaml
+++ b/.devcontainer/docker-compose.devcontainer.yaml
@@ -1,0 +1,17 @@
+services:
+  devcontainer:
+    # Required for ptrace-based debuggers like C++, Go, and Rust
+    cap_add:
+      - SYS_PTRACE
+    command: sleep infinity
+    depends_on:
+      - squid
+    image: mcr.microsoft.com/devcontainers/base:trixie
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      # Mounts the project folder to '/workspace'. The target path inside the container
+      # should match what your application expects. In this case, the compose file is
+      # in a sub-folder, so you will mount '..'. You would then reference this path as the
+      # 'workspaceFolder' in '.devcontainer/devcontainer.json' so VS Code starts here.
+      - .:/workspace:cached

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@
 
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "docker"
+    directory: "/" # Location of Dockerfile
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-app.yaml
+++ b/.github/workflows/test-app.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Test App
 
 on:
   push:
@@ -7,8 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-
-  test:
+  test-app:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-goreleaser.yaml
+++ b/.github/workflows/test-goreleaser.yaml
@@ -1,0 +1,39 @@
+name: Test Goreleaser
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test-goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Verify goreleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+
+      - name: Test goreleaser build
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+dist/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,13 +13,15 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
 
 archives:
   - builds_info:
       group: root
       owner: root
     wrap_in_directory: true
-    format: tar.gz
+    formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
@@ -31,18 +33,21 @@ archives:
     # use zip for windows archives
     format_overrides:
     - goos: windows
-      format: zip
+      formats:
+        - zip
 
-dockers:
-  - image_templates:
-      - "ghcr.io/persona-id/{{.ProjectName}}:{{ .Tag }}"
-      - "ghcr.io/persona-id/{{.ProjectName}}:latest"
+dockers_v2:
+  - images:
+    - "ghcr.io/persona-id/{{.ProjectName}}"
+    tags:
+      - "{{ .Tag }}"
+      - "latest"
 
 checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
-* startup message log level([#12](https://github.com/persona-id/squid-check/issues/12)) ([4bdc55a](https://github.com/persona-id/squid-check/commit/4bdc55a727db2a1f37d9c1d11e8a454e5b0207d3))
+* startup message log level ([#12](https://github.com/persona-id/squid-check/issues/12)) ([4bdc55a](https://github.com/persona-id/squid-check/commit/4bdc55a727db2a1f37d9c1d11e8a454e5b0207d3))
 
 ## [0.1.0](https://github.com/persona-id/squid-check/compare/v0.0.2...v0.1.0) (2024-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 * forcing new release to include recent changes for 0.2.0 ([#13](https://github.com/persona-id/squid-check/issues/13)) ([65ca2d9](https://github.com/persona-id/squid-check/commit/65ca2d9f9aa673f237528aa8e1851379dd2aba96))
 
+
+### Bug Fixes
+
+* startup message log level([#12](https://github.com/persona-id/squid-check/issues/12)) ([4bdc55a](https://github.com/persona-id/squid-check/commit/4bdc55a727db2a1f37d9c1d11e8a454e5b0207d3))
+
 ## [0.1.0](https://github.com/persona-id/squid-check/compare/v0.0.2...v0.1.0) (2024-07-05)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM alpine:3.18
+FROM debian:13.1-slim
 
-RUN adduser -DH -u 1337 app
+# Goreleaser builds a multi-arch binary and copies them into the image.
+# The arch binaries are sorted into directories after the build arch
+# https://goreleaser.com/customization/dockers_v2
+ARG TARGETPLATFORM
 
-COPY squid-check /usr/local/bin/squid-check
+RUN useradd --no-create-home -u 1337 -p '*' app
+
+COPY $TARGETPLATFORM/squid-check /usr/local/bin/squid-check
 
 USER 1337
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+BINARY := squid-check
+
+.PHONY: help build clean run test
+
+default: help
+
+build: ## Build the application
+	@go build ./...
+
+clean: ## Clean build artifacts and coverage files
+	@go clean
+	@rm -rf $(BINARY) dist
+
+help: ## Show this help message
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# Runs the application in either the local environment (my laptop) or the devcontainer.
+run: clean build ## Run the application
+	@if [ "$$REMOTE_CONTAINERS" = "true" ] || [ "$$CODESPACES" = "true" ] || [ "$$VSCODE_REMOTE_CONTAINERS_SESSION" = "true" ]; then \
+		echo "=> Running in remote container"; \
+		./$(BINARY) --proxy-address=squid:3128 --target-address=devcontainer:8080 --log-level=debug; \
+	else \
+		echo "=> Running in local environment"; \
+		./$(BINARY) --log-level=debug; \
+	fi
+
+snapshot: clean ## Build a snapshot of the docker image using goreleaser
+	@goreleaser release --snapshot --clean
+
+test: ## Run tests
+	@echo "=> Running go test --race --shuffle=on ./..."
+	@go test -v --race --shuffle=on ./...

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage of /usr/local/bin/squid-check:
   -listen-address string
         Address to listen on (default "0.0.0.0:8080")
   -log-level string
-        Log level (default "warn")
+        Log level (default "info")
   -proxy-address string
         Address of squid proxy (default "127.0.0.1:3128")
   -target-address string
@@ -103,11 +103,20 @@ docker pull ghcr.io/persona-id/squid-check:latest
 
 ## Development
 
+### Devcontainer
+
+If you are using vscode you can develop in the devcontainer included in the repo. The devcontainer in this repo will connect you to a debian devcontainer instance with go already installed. There is also a docker compose sidecar that is attached to the same network running squid. This allows developing squid-check changes directly against a local instance of squid without any additional setup.
+
+1. When prompted by vscode, choose to re-open in a container. This will relaunch your ide and attach it to the `devconatiner` service.
+2. If you would like to run squid-check use `make run`. You can also run tests in the container with `make test`.
+
+### Docker Compose
+
 There is a docker compose file to provide a local development environment. The compose file consists of a container running `squid-check` and an additional container running squid.
 
 To use the environment:
 
-1. `docker-compose up --build`
+1. `docker compose up --build`
 2. Make requests to `http://localhost:8080/healthz` or another endpoint served by squid-check. If you have the vscode rest client installed you can use `http_client_tests.rest` to send requests to the various endpoints.
 
 ## Releasing

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,7 +1,7 @@
 # build stage
-FROM golang:1.21.4-alpine3.18 AS build
+FROM golang:1.25.1-trixie AS build
 
-RUN adduser -DH -u 1337 app
+RUN useradd --no-create-home -u 1337 -p '*' app
 
 WORKDIR /usr/src/app
 
@@ -13,9 +13,10 @@ COPY . .
 RUN go build -v -o /usr/local/bin/squid-check ./...
 
 # run stage
-FROM scratch
+FROM debian:13.1-slim
 
-COPY --from=build /etc/passwd /etc/passwd
+RUN useradd --no-create-home -u 1337 -p '*' app
+
 COPY --from=build /usr/local/bin/squid-check /usr/local/bin/squid-check
 
 USER 1337

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,16 @@
 services:
+  squid:
+    image: "ubuntu/squid:latest"
+
   squid-check:
     build:
       context: .
       dockerfile: dev.dockerfile
-    ports:
-      - "8080:8080"
+    depends_on:
+      - squid
     command:
       - --proxy-address=squid:3128
       - --target-address=squid-check:8080
       - --log-level=debug
-
-  squid:
-    image: "ubuntu/squid:latest"
+    ports:
+      - "8080:8080"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/persona-id/squid-check
 
-go 1.22.4
+go 1.25.1


### PR DESCRIPTION
Update go version to 1.25.1 in container images and `go.mod`.

Add devcontainer to make development easier. This will run squid as a sidecar
to enable end-to-end testing with squid-check. `goreleaser` is also installed
in the devcontainer.

Also fixed a bug with the dependabot config file extension.

Updated docker images to use debian and work with the new goreleaser
dockerv2 config. In the process of updating the goreleaser config, we are
now building for arm64 as well as amd64.